### PR TITLE
Refactor duplicated logic into reusable classes

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Category;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use App\Http\Requests\CategoryRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -29,15 +30,9 @@ class CategoryController extends Controller
         ]);
     }
 
-    public function store(Request $request)
+    public function store(CategoryRequest $request)
     {
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'color' => ['nullable', 'string', 'max:7'],
-            'icon' => ['nullable', 'string', 'max:255'],
-            'parent_category_id' => ['nullable', 'string'],
-        ]);
+        $validated = $request->validated();
 
         $data = $validated;
         if ($data['parent_category_id'] === '0') {
@@ -51,17 +46,11 @@ class CategoryController extends Controller
         return redirect()->back()->with('success', 'Category created successfully');
     }
 
-    public function update(Request $request, Category $category)
+    public function update(CategoryRequest $request, Category $category)
     {
         $this->authorize('update', $category);
 
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'color' => ['nullable', 'string', 'max:7'],
-            'icon' => ['nullable', 'string', 'max:255'],
-            'parent_category_id' => ['nullable', 'string'],
-        ]);
+        $validated = $request->validated();
 
         $data = $validated;
         if ($data['parent_category_id'] === '0') {

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\CategoryRequest;
 use App\Models\Category;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use App\Http\Requests\CategoryRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;

--- a/app/Http/Controllers/MerchantController.php
+++ b/app/Http/Controllers/MerchantController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Merchant;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use App\Http\Requests\MerchantRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
@@ -21,28 +22,20 @@ class MerchantController extends Controller
         ]);
     }
 
-    public function store(Request $request)
+    public function store(MerchantRequest $request)
     {
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'logo' => ['nullable', 'string', 'max:255'],
-        ]);
+        $validated = $request->validated();
 
         $merchant = Auth::user()->merchants()->create($validated);
 
         return redirect()->back()->with('success', 'Merchant created successfully');
     }
 
-    public function update(Request $request, Merchant $merchant)
+    public function update(MerchantRequest $request, Merchant $merchant)
     {
         $this->authorize('update', $merchant);
 
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'logo' => ['nullable', 'string', 'max:255'],
-        ]);
+        $validated = $request->validated();
 
         $merchant->update($validated);
 

--- a/app/Http/Controllers/MerchantController.php
+++ b/app/Http/Controllers/MerchantController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\MerchantRequest;
 use App\Models\Merchant;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use App\Http\Requests\MerchantRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Tag;
-use Illuminate\Http\Request;
+use App\Http\Requests\TagRequest;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 
@@ -18,26 +18,20 @@ class TagController extends Controller
         ]);
     }
 
-    public function store(Request $request)
+    public function store(TagRequest $request)
     {
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'color' => ['nullable', 'string', 'max:7'],
-        ]);
+        $validated = $request->validated();
 
         $tag = Auth::user()->tags()->create($validated);
 
         return redirect()->back()->with('success', 'Tag created successfully');
     }
 
-    public function update(Request $request, Tag $tag)
+    public function update(TagRequest $request, Tag $tag)
     {
         $this->authorize('update', $tag);
 
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'color' => ['nullable', 'string', 'max:7'],
-        ]);
+        $validated = $request->validated();
 
         $tag->update($validated);
 

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Tag;
 use App\Http\Requests\TagRequest;
+use App\Models\Tag;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 

--- a/app/Http/Requests/CategoryRequest.php
+++ b/app/Http/Requests/CategoryRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'color' => ['nullable', 'string', 'max:7'],
+            'icon' => ['nullable', 'string', 'max:255'],
+            'parent_category_id' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/MerchantRequest.php
+++ b/app/Http/Requests/MerchantRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MerchantRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'logo' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/TagRequest.php
+++ b/app/Http/Requests/TagRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TagRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'color' => ['nullable', 'string', 'max:7'],
+        ];
+    }
+}

--- a/app/Policies/CategoryPolicy.php
+++ b/app/Policies/CategoryPolicy.php
@@ -3,7 +3,6 @@
 namespace App\Policies;
 
 use App\Models\Category;
-use App\Models\User;
 
 class CategoryPolicy extends OwnedByUserPolicy
 {

--- a/app/Policies/CategoryPolicy.php
+++ b/app/Policies/CategoryPolicy.php
@@ -4,49 +4,8 @@ namespace App\Policies;
 
 use App\Models\Category;
 use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
 
-class CategoryPolicy
+class CategoryPolicy extends OwnedByUserPolicy
 {
-    use HandlesAuthorization;
-
-    /**
-     * Determine whether the user can view any models.
-     */
-    public function viewAny(User $user): bool
-    {
-        return true;
-    }
-
-    /**
-     * Determine whether the user can view the model.
-     */
-    public function view(User $user, Category $category): bool
-    {
-        return $user->id === $category->user_id;
-    }
-
-    /**
-     * Determine whether the user can create models.
-     */
-    public function create(User $user): bool
-    {
-        return true;
-    }
-
-    /**
-     * Determine whether the user can update the model.
-     */
-    public function update(User $user, Category $category): bool
-    {
-        return $user->id === $category->user_id;
-    }
-
-    /**
-     * Determine whether the user can delete the model.
-     */
-    public function delete(User $user, Category $category): bool
-    {
-        return $user->id === $category->user_id;
-    }
+    // Additional category-specific authorization logic can be placed here
 }

--- a/app/Policies/MerchantPolicy.php
+++ b/app/Policies/MerchantPolicy.php
@@ -4,49 +4,8 @@ namespace App\Policies;
 
 use App\Models\Merchant;
 use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
 
-class MerchantPolicy
+class MerchantPolicy extends OwnedByUserPolicy
 {
-    use HandlesAuthorization;
-
-    /**
-     * Determine whether the user can view any models.
-     */
-    public function viewAny(User $user): bool
-    {
-        return true;
-    }
-
-    /**
-     * Determine whether the user can view the model.
-     */
-    public function view(User $user, Merchant $merchant): bool
-    {
-        return $user->id === $merchant->user_id;
-    }
-
-    /**
-     * Determine whether the user can create models.
-     */
-    public function create(User $user): bool
-    {
-        return true;
-    }
-
-    /**
-     * Determine whether the user can update the model.
-     */
-    public function update(User $user, Merchant $merchant): bool
-    {
-        return $user->id === $merchant->user_id;
-    }
-
-    /**
-     * Determine whether the user can delete the model.
-     */
-    public function delete(User $user, Merchant $merchant): bool
-    {
-        return $user->id === $merchant->user_id;
-    }
+    // Additional merchant-specific authorization logic can be placed here
 }

--- a/app/Policies/MerchantPolicy.php
+++ b/app/Policies/MerchantPolicy.php
@@ -3,7 +3,6 @@
 namespace App\Policies;
 
 use App\Models\Merchant;
-use App\Models\User;
 
 class MerchantPolicy extends OwnedByUserPolicy
 {

--- a/app/Policies/OwnedByUserPolicy.php
+++ b/app/Policies/OwnedByUserPolicy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+abstract class OwnedByUserPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, $model): bool
+    {
+        return $user->id === $model->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, $model): bool
+    {
+        return $user->id === $model->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, $model): bool
+    {
+        return $user->id === $model->user_id;
+    }
+}

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -3,7 +3,6 @@
 namespace App\Policies;
 
 use App\Models\Tag;
-use App\Models\User;
 
 class TagPolicy extends OwnedByUserPolicy
 {

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -1,1 +1,11 @@
- 
+<?php
+
+namespace App\Policies;
+
+use App\Models\Tag;
+use App\Models\User;
+
+class TagPolicy extends OwnedByUserPolicy
+{
+    // Additional tag-specific authorization logic can be placed here
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,8 +4,10 @@ namespace App\Providers;
 
 use App\Models\Category;
 use App\Models\Merchant;
+use App\Models\Tag;
 use App\Policies\CategoryPolicy;
 use App\Policies\MerchantPolicy;
+use App\Policies\TagPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -18,6 +20,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         Category::class => CategoryPolicy::class,
         Merchant::class => MerchantPolicy::class,
+        Tag::class => TagPolicy::class,
     ];
 
     /**

--- a/resources/js/components/accounts/CreateAccountModal.tsx
+++ b/resources/js/components/accounts/CreateAccountModal.tsx
@@ -1,6 +1,6 @@
 import { SelectInput, TextInput } from '@/components/ui/form-inputs';
-import { InferFormValues } from '@/components/ui/smart-form';
 import { FormModal } from '@/components/ui/form-modal';
+import { InferFormValues } from '@/components/ui/smart-form';
 import { Currency } from '@/types/index';
 import { z } from 'zod';
 

--- a/resources/js/components/accounts/CreateAccountModal.tsx
+++ b/resources/js/components/accounts/CreateAccountModal.tsx
@@ -1,7 +1,6 @@
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { SelectInput, TextInput } from '@/components/ui/form-inputs';
-import { InferFormValues, SmartForm } from '@/components/ui/smart-form';
+import { InferFormValues } from '@/components/ui/smart-form';
+import { FormModal } from '@/components/ui/form-modal';
 import { Currency } from '@/types/index';
 import { z } from 'zod';
 
@@ -44,54 +43,44 @@ export default function CreateAccountModal({ isOpen, onClose, onSubmit }: Create
 
     const handleSubmit = (values: FormValues) => {
         onSubmit(values);
-        onClose();
     };
 
     return (
-        <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Create New Account</DialogTitle>
-                    <DialogDescription>Fill in the details to create a new account.</DialogDescription>
-                </DialogHeader>
-                <SmartForm schema={formSchema} defaultValues={defaultValues} onSubmit={handleSubmit} formProps={{ className: 'space-y-4' }}>
-                    {() => (
-                        <>
-                            <TextInput<FormValues> name="name" label="Account Name" required />
-
-                            <TextInput<FormValues> name="account_id" label="Account ID" required />
-
-                            <SelectInput<FormValues>
-                                name="type"
-                                label="Account Type"
-                                options={[
-                                    { value: 'Default', label: 'Default' },
-                                    { value: 'Manual', label: 'Manual' },
-                                ]}
-                            />
-
-                            <TextInput<FormValues> name="bank_name" label="Bank Name" required />
-
-                            <TextInput<FormValues> name="iban" label="IBAN" required />
-
-                            <SelectInput<FormValues>
-                                name="currency"
-                                label="Currency"
-                                options={Object.values(Currency).map((currency) => ({
-                                    value: currency,
-                                    label: currency,
-                                }))}
-                            />
-
-                            <TextInput<FormValues> name="balance" label="Initial Balance" type="number" required />
-
-                            <DialogFooter>
-                                <Button type="submit">Create Account</Button>
-                            </DialogFooter>
-                        </>
-                    )}
-                </SmartForm>
-            </DialogContent>
-        </Dialog>
+        <FormModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title="Create New Account"
+            description="Fill in the details to create a new account."
+            schema={formSchema}
+            defaultValues={defaultValues}
+            onSubmit={handleSubmit}
+            submitLabel="Create Account"
+        >
+            {() => (
+                <>
+                    <TextInput<FormValues> name="name" label="Account Name" required />
+                    <TextInput<FormValues> name="account_id" label="Account ID" required />
+                    <SelectInput<FormValues>
+                        name="type"
+                        label="Account Type"
+                        options={[
+                            { value: 'Default', label: 'Default' },
+                            { value: 'Manual', label: 'Manual' },
+                        ]}
+                    />
+                    <TextInput<FormValues> name="bank_name" label="Bank Name" required />
+                    <TextInput<FormValues> name="iban" label="IBAN" required />
+                    <SelectInput<FormValues>
+                        name="currency"
+                        label="Currency"
+                        options={Object.values(Currency).map((currency) => ({
+                            value: currency,
+                            label: currency,
+                        }))}
+                    />
+                    <TextInput<FormValues> name="balance" label="Initial Balance" type="number" required />
+                </>
+            )}
+        </FormModal>
     );
 }

--- a/resources/js/components/transactions/CreateTransactionModal.tsx
+++ b/resources/js/components/transactions/CreateTransactionModal.tsx
@@ -1,7 +1,6 @@
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { SelectInput, TextInput } from '@/components/ui/form-inputs';
-import { InferFormValues, SmartForm } from '@/components/ui/smart-form';
+import { InferFormValues } from '@/components/ui/smart-form';
+import { FormModal } from '@/components/ui/form-modal';
 import { Transaction } from '@/types/index';
 import { z } from 'zod';
 
@@ -66,49 +65,34 @@ export default function CreateTransactionModal({ isOpen, onClose, onSubmit }: Cr
     const handleSubmit = (values: FormValues) => {
         onSubmit({
             ...values,
-            balance_after_transaction: values.amount, // Set initial balance to amount
+            balance_after_transaction: values.amount,
         });
-        onClose();
     };
 
     return (
-        <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>New Transaction</DialogTitle>
-                    <DialogDescription>Fill in the details to create a new transaction.</DialogDescription>
-                </DialogHeader>
-                <SmartForm schema={transactionSchema} defaultValues={defaultValues} onSubmit={handleSubmit} formProps={{ className: 'space-y-4' }}>
-                    {() => (
-                        <>
-                            <TextInput<FormValues> name="partner" label="Partner" required />
-
-                            <TextInput<FormValues> name="amount" label="Amount" type="number" required />
-
-                            <SelectInput<FormValues> name="currency" label="Currency" options={currencies} required />
-
-                            <TextInput<FormValues> name="description" label="Description" required />
-
-                            <SelectInput<FormValues> name="type" label="Type" options={transactionTypes} required />
-
-                            <TextInput<FormValues> name="target_iban" label="Target IBAN" />
-
-                            <TextInput<FormValues> name="source_iban" label="Source IBAN" />
-
-                            <TextInput<FormValues> name="booked_date" label="Booked Date" type="date" required />
-
-                            <TextInput<FormValues> name="processed_date" label="Processed Date" type="date" required />
-
-                            <DialogFooter>
-                                <Button type="button" variant="outline" onClick={onClose}>
-                                    Cancel
-                                </Button>
-                                <Button type="submit">Create Transaction</Button>
-                            </DialogFooter>
-                        </>
-                    )}
-                </SmartForm>
-            </DialogContent>
-        </Dialog>
+        <FormModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title="New Transaction"
+            description="Fill in the details to create a new transaction."
+            schema={transactionSchema}
+            defaultValues={defaultValues}
+            onSubmit={handleSubmit}
+            submitLabel="Create Transaction"
+        >
+            {() => (
+                <>
+                    <TextInput<FormValues> name="partner" label="Partner" required />
+                    <TextInput<FormValues> name="amount" label="Amount" type="number" required />
+                    <SelectInput<FormValues> name="currency" label="Currency" options={currencies} required />
+                    <TextInput<FormValues> name="description" label="Description" required />
+                    <SelectInput<FormValues> name="type" label="Type" options={transactionTypes} required />
+                    <TextInput<FormValues> name="target_iban" label="Target IBAN" />
+                    <TextInput<FormValues> name="source_iban" label="Source IBAN" />
+                    <TextInput<FormValues> name="booked_date" label="Booked Date" type="date" required />
+                    <TextInput<FormValues> name="processed_date" label="Processed Date" type="date" required />
+                </>
+            )}
+        </FormModal>
     );
 }

--- a/resources/js/components/transactions/CreateTransactionModal.tsx
+++ b/resources/js/components/transactions/CreateTransactionModal.tsx
@@ -1,6 +1,6 @@
 import { SelectInput, TextInput } from '@/components/ui/form-inputs';
-import { InferFormValues } from '@/components/ui/smart-form';
 import { FormModal } from '@/components/ui/form-modal';
+import { InferFormValues } from '@/components/ui/smart-form';
 import { Transaction } from '@/types/index';
 import { z } from 'zod';
 

--- a/resources/js/components/ui/form-modal.tsx
+++ b/resources/js/components/ui/form-modal.tsx
@@ -1,0 +1,45 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './dialog';
+import { SmartForm, InferFormValues } from './smart-form';
+import { Button } from './button';
+import { z } from 'zod';
+import { ReactNode } from 'react';
+
+interface FormModalProps<T extends z.ZodTypeAny> {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    description?: string;
+    schema: T;
+    defaultValues: InferFormValues<T>;
+    onSubmit: (values: InferFormValues<T>) => void;
+    submitLabel?: string;
+    children: () => ReactNode;
+}
+
+export function FormModal<T extends z.ZodTypeAny>({ isOpen, onClose, title, description, schema, defaultValues, onSubmit, submitLabel = 'Submit', children }: FormModalProps<T>) {
+    const handleSubmit = (values: InferFormValues<T>) => {
+        onSubmit(values);
+        onClose();
+    };
+
+    return (
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    {description && <DialogDescription>{description}</DialogDescription>}
+                </DialogHeader>
+                <SmartForm schema={schema} defaultValues={defaultValues} onSubmit={handleSubmit} formProps={{ className: 'space-y-4' }}>
+                    {() => (
+                        <>
+                            {children()}
+                            <DialogFooter>
+                                <Button type="submit">{submitLabel}</Button>
+                            </DialogFooter>
+                        </>
+                    )}
+                </SmartForm>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -32,9 +32,9 @@ Route::middleware('auth')->group(function () {
         Route::post('/requisitions', [BankDataController::class, 'createRequisition']);
         Route::delete('/requisitions/{id}', [BankDataController::class, 'deleteRequisition']);
         Route::get('/requisition/callback', [BankDataController::class, 'handleRequisitionCallback'])
-            ->withoutMiddleware(['auth'])
-            // TODO: Uncomment this when we have a proper signed URL
-            // ->middleware('signed'); // or create a custom token/verify middleware
+            ->withoutMiddleware(['auth']);
+        // TODO: Uncomment this when we have a proper signed URL
+        // ->middleware('signed'); // or create a custom token/verify middleware
         Route::post('/import/account', [BankDataController::class, 'importAccount']);
         Route::post('/accounts/{account}/sync-transactions', [BankDataController::class, 'syncAccountTransactions']);
     });


### PR DESCRIPTION
## Summary
- reuse base policy to remove policy duplication
- create form modal and use in account/transaction modals
- add form request classes for category, merchant, and tag
- register Tag policy

## Testing
- `npm test` *(fails: Missing script)*
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df0d85f408328bf9cd05ce7be551d