### PR TITLE
Add fingerprint-based duplicate detection

### DIFF
--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -34,6 +34,13 @@ class Transaction extends Model
         'is_gocardless_synced',
         'gocardless_synced_at',
         'gocardless_account_id',
+        'duplicate_identifier',
+        'original_amount',
+        'original_currency',
+        'original_booked_date',
+        'original_source_iban',
+        'original_target_iban',
+        'original_partner',
     ];
 
     /**
@@ -53,6 +60,13 @@ class Transaction extends Model
         'is_gocardless_synced' => 'boolean',
         'gocardless_synced_at' => 'datetime',
         'gocardless_account_id' => 'string',
+        'duplicate_identifier' => 'string',
+        'original_amount' => 'decimal:2',
+        'original_currency' => 'string',
+        'original_booked_date' => 'datetime',
+        'original_source_iban' => 'string',
+        'original_target_iban' => 'string',
+        'original_partner' => 'string',
     ];
 
     /**

--- a/app/Models/TransactionFingerprint.php
+++ b/app/Models/TransactionFingerprint.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TransactionFingerprint extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'fingerprint',
+        'transaction_id',
+    ];
+
+    public function transaction(): BelongsTo
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/DuplicateTransactionService.php
+++ b/app/Services/DuplicateTransactionService.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Transaction;
+use App\Models\TransactionFingerprint;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+
+class DuplicateTransactionService
+{
+    /**
+     * Mapping of canonical field names to possible aliases.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private array $fieldMapping;
+
+    public function __construct(array $fieldMapping = [])
+    {
+        $this->fieldMapping = $fieldMapping;
+    }
+
+    /**
+     * Normalize a transaction record using field aliases.
+     *
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
+    public function normalizeRecord(array $input): array
+    {
+        $normalized = [
+            'description' => null,
+            'booked_date' => null,
+            'processed_date' => $input['processed_date'] ?? null,
+            'amount' => $input['amount'] ?? null,
+            'reference_id' => null,
+        ];
+
+        foreach (['description', 'booked_date', 'reference_id'] as $canonical) {
+            if (isset($input[$canonical]) && $input[$canonical] !== null) {
+                $normalized[$canonical] = $input[$canonical];
+                continue;
+            }
+            foreach ($this->fieldMapping[$canonical] ?? [] as $alias) {
+                if (! empty($input[$alias])) {
+                    $normalized[$canonical] = $input[$alias];
+                    break;
+                }
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Build a SHA-256 fingerprint from normalized data.
+     *
+     * @param  array<string, mixed>  $normalized
+     */
+    public function buildFingerprint(array $normalized): string
+    {
+        $date = $normalized['booked_date'] ?? $normalized['processed_date'];
+        try {
+            $date = Carbon::parse((string) $date)->toDateString();
+        } catch (\Exception $e) {
+            $date = '';
+        }
+
+        $amount = abs((float) ($normalized['amount'] ?? 0));
+        $desc = strtolower(preg_replace('/[^a-z0-9]/i', '', (string) ($normalized['description'] ?? '')));
+        $reference = (string) ($normalized['reference_id'] ?? '');
+
+        return hash('sha256', $date.'|'.$amount.'|'.$desc.'|'.$reference);
+    }
+
+    /**
+     * Fetch candidate transactions within ±1 day for the same user.
+     *
+     * @param  array<string, mixed>  $normalized
+     */
+    public function fetchCandidates(array $normalized, int $userId): Collection
+    {
+        $date = $normalized['booked_date'] ?? $normalized['processed_date'];
+        try {
+            $date = Carbon::parse((string) $date);
+        } catch (\Exception $e) {
+            return collect();
+        }
+
+        $start = $date->copy()->subDay()->startOfDay();
+        $end = $date->copy()->addDay()->endOfDay();
+
+        return Transaction::whereHas('account', static function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })
+            ->whereBetween('booked_date', [$start, $end])
+            ->get();
+    }
+
+    /**
+     * Compute a weighted duplicate score against an existing transaction.
+     *
+     * @param  array<string, mixed>  $normalized
+     */
+    public function computeScore(array $normalized, Transaction $existing): float
+    {
+        $dateMatch = false;
+        try {
+            $inputDate = Carbon::parse((string) ($normalized['booked_date'] ?? $normalized['processed_date']))->toDateString();
+            $dateMatch = $existing->booked_date->toDateString() === $inputDate;
+        } catch (\Exception $e) {
+            // ignore parsing errors
+        }
+
+        $amountMatch = abs((float) $existing->amount) === abs((float) ($normalized['amount'] ?? 0));
+        $referenceExact = isset($normalized['reference_id']) && $existing->transaction_id === $normalized['reference_id'];
+
+        $descriptionScore = TextSimilarity::similarity((string) $existing->description, (string) ($normalized['description'] ?? ''));
+        $descriptionScore = $descriptionScore >= 0.90 ? 1.0 : 0.0;
+
+        return ($dateMatch ? 0.50 : 0.0)
+            + ($amountMatch ? 0.30 : 0.0)
+            + ($descriptionScore * 0.15)
+            + ($referenceExact ? 0.05 : 0.0);
+    }
+
+    /**
+     * Determine if a record is a duplicate for the given user.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function isDuplicate(array $input, int $userId): bool
+    {
+        $normalized = $this->normalizeRecord($input);
+        $fingerprint = $this->buildFingerprint($normalized);
+
+        $exists = TransactionFingerprint::where('user_id', $userId)
+            ->where('fingerprint', $fingerprint)
+            ->exists();
+        if ($exists) {
+            return true;
+        }
+
+        $candidates = $this->fetchCandidates($normalized, $userId);
+        foreach ($candidates as $candidate) {
+            if ($this->computeScore($normalized, $candidate) >= 0.80) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Backwards compatibility wrapper for old check method.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  int  $accountId
+     * @return array{duplicate: bool, level: int, identifier: string, fields: array<string, mixed>}
+     */
+    public function check(array $data, int $accountId): array
+    {
+        $normalized = $this->normalizeRecord($data);
+        $identifier = $this->buildFingerprint($normalized);
+        $duplicate = $this->isDuplicate($data, $accountId);
+
+        return [
+            'duplicate' => $duplicate,
+            'level' => $duplicate ? 5 : 0,
+            'identifier' => $identifier,
+            'fields' => $normalized,
+        ];
+    }
+}

--- a/app/Services/TextSimilarity.php
+++ b/app/Services/TextSimilarity.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+class TextSimilarity
+{
+    public static function preprocess(string $text): string
+    {
+        $text = strip_tags($text);
+        $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+        $text = iconv('UTF-8', 'ASCII//TRANSLIT', $text);
+        $text = strtolower($text);
+        $text = preg_replace('/[\p{P}]/u', '', $text);
+        $text = preg_replace('/\s+/', ' ', $text);
+
+        return trim($text);
+    }
+
+    public static function similarity(string $a, string $b): float
+    {
+        $a = self::preprocess($a);
+        $b = self::preprocess($b);
+
+        if ($a === '' && $b === '') {
+            return 1.0;
+        }
+
+        $maxLen = max(strlen($a), strlen($b));
+        if ($maxLen === 0) {
+            return 0.0;
+        }
+
+        $distance = levenshtein($a, $b);
+
+        return 1 - ($distance / $maxLen);
+    }
+}

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -16,6 +16,20 @@ class TransactionFactory extends Factory
         $type = $this->faker->randomElement($types);
         $amount = $this->faker->randomFloat(2, -1000, 2000);
         $date = $this->faker->dateTimeBetween('-3 months', 'now');
+        $targetIban = $type === 'TRANSFER' ? $this->faker->iban('SK') : null;
+        $sourceIban = $type === 'TRANSFER' ? $this->faker->iban('SK') : null;
+        $partner = $this->faker->company();
+
+        $identifierFields = [
+            'amount' => $amount,
+            'currency' => 'EUR',
+            'booked_date' => $date->format('Y-m-d H:i:s'),
+            'source_iban' => $sourceIban,
+            'target_iban' => $targetIban,
+            'partner' => $partner,
+        ];
+        ksort($identifierFields);
+        $identifier = hash('sha256', json_encode($identifierFields));
 
         return [
             'transaction_id' => 'TRX-'.$this->faker->unique()->numerify('######'),
@@ -24,13 +38,20 @@ class TransactionFactory extends Factory
             'booked_date' => $date,
             'processed_date' => $date,
             'description' => $this->faker->sentence(3),
-            'target_iban' => $type === 'TRANSFER' ? $this->faker->iban('SK') : null,
-            'source_iban' => $type === 'TRANSFER' ? $this->faker->iban('SK') : null,
-            'partner' => $this->faker->company(),
+            'target_iban' => $targetIban,
+            'source_iban' => $sourceIban,
+            'partner' => $partner,
             'type' => $type,
             'metadata' => null,
             'balance_after_transaction' => $amount,
             'account_id' => Account::first()->id,
+            'duplicate_identifier' => $identifier,
+            'original_amount' => $identifierFields['amount'],
+            'original_currency' => $identifierFields['currency'],
+            'original_booked_date' => $identifierFields['booked_date'],
+            'original_source_iban' => $identifierFields['source_iban'],
+            'original_target_iban' => $identifierFields['target_iban'],
+            'original_partner' => $identifierFields['partner'],
         ];
     }
 }

--- a/database/migrations/2025_06_30_120000_add_duplicate_tracking_to_transactions_table.php
+++ b/database/migrations/2025_06_30_120000_add_duplicate_tracking_to_transactions_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (! Schema::hasColumn('transactions', 'duplicate_identifier')) {
+                $table->string('duplicate_identifier', 64)->nullable()->after('gocardless_account_id');
+            }
+            if (! Schema::hasColumn('transactions', 'original_amount')) {
+                $table->decimal('original_amount', 10, 2)->nullable()->after('duplicate_identifier');
+            }
+            if (! Schema::hasColumn('transactions', 'original_currency')) {
+                $table->string('original_currency', 3)->nullable()->after('original_amount');
+            }
+            if (! Schema::hasColumn('transactions', 'original_booked_date')) {
+                $table->timestamp('original_booked_date')->nullable()->after('original_currency');
+            }
+            if (! Schema::hasColumn('transactions', 'original_source_iban')) {
+                $table->string('original_source_iban', 34)->nullable()->after('original_booked_date');
+            }
+            if (! Schema::hasColumn('transactions', 'original_target_iban')) {
+                $table->string('original_target_iban', 34)->nullable()->after('original_source_iban');
+            }
+            if (! Schema::hasColumn('transactions', 'original_partner')) {
+                $table->string('original_partner')->nullable()->after('original_target_iban');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (Schema::hasColumn('transactions', 'duplicate_identifier')) {
+                $table->dropColumn('duplicate_identifier');
+            }
+            if (Schema::hasColumn('transactions', 'original_amount')) {
+                $table->dropColumn('original_amount');
+            }
+            if (Schema::hasColumn('transactions', 'original_currency')) {
+                $table->dropColumn('original_currency');
+            }
+            if (Schema::hasColumn('transactions', 'original_booked_date')) {
+                $table->dropColumn('original_booked_date');
+            }
+            if (Schema::hasColumn('transactions', 'original_source_iban')) {
+                $table->dropColumn('original_source_iban');
+            }
+            if (Schema::hasColumn('transactions', 'original_target_iban')) {
+                $table->dropColumn('original_target_iban');
+            }
+            if (Schema::hasColumn('transactions', 'original_partner')) {
+                $table->dropColumn('original_partner');
+            }
+        });
+    }
+};

--- a/database/migrations/2025_07_01_000000_create_transaction_fingerprints_table.php
+++ b/database/migrations/2025_07_01_000000_create_transaction_fingerprints_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('transaction_fingerprints', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('fingerprint', 64);
+            $table->foreignId('transaction_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+            $table->unique(['user_id', 'fingerprint']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_fingerprints');
+    }
+};

--- a/resources/js/pages/transactions/index.tsx
+++ b/resources/js/pages/transactions/index.tsx
@@ -125,7 +125,7 @@ async function fetchTransactions(
         };
     }
 
-    function getHasMorePages(data: any): boolean {
+    function getHasMorePages(data: Record<string, unknown>): boolean {
         return data.transactions?.has_more_pages ?? data.transactions?.hasMorePages ?? data.hasMorePages ?? false;
     }
     throw new Error(`Invalid response from endpoint "${endpoint}". Response data: ${JSON.stringify(response.data)}`);

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -74,6 +74,13 @@ interface TransactionType {
     metadata: Record<string, unknown> | null;
     balance_after_transaction: number;
     account_id: number | null;
+    duplicate_identifier?: string;
+    original_amount?: number;
+    original_currency?: string;
+    original_booked_date?: string;
+    original_source_iban?: string;
+    original_target_iban?: string;
+    original_partner?: string;
     created_at: string;
     updated_at: string;
     account: Account | null;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -38,6 +38,13 @@ export interface Transaction {
     metadata?: Record<string, unknown> | undefined;
     balance_after_transaction: number;
     account_id: number;
+    duplicate_identifier?: string;
+    original_amount?: number;
+    original_currency?: string;
+    original_booked_date?: string;
+    original_source_iban?: string;
+    original_target_iban?: string;
+    original_partner?: string;
     import_data?: Record<string, unknown> | undefined;
     merchant_id?: number;
     category_id?: number;

--- a/tests/Unit/DuplicateTransactionServiceTest.php
+++ b/tests/Unit/DuplicateTransactionServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\TransactionFingerprint;
+use App\Models\User;
+use App\Services\DuplicateTransactionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DuplicateTransactionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DuplicateTransactionService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $mapping = [
+            'description' => ['notes', 'description'],
+            'booked_date' => ['booked_date', 'date'],
+            'reference_id' => ['reference', 'transaction_id'],
+        ];
+        $this->service = new DuplicateTransactionService($mapping);
+    }
+
+    public static function duplicateProvider(): array
+    {
+        return [
+            'exact duplicate' => [
+                [
+                    'booked_date' => '2024-01-01',
+                    'processed_date' => '2024-01-01',
+                    'amount' => 9.99,
+                    'description' => 'Netflix EU',
+                    'transaction_id' => 'abc',
+                ],
+                [
+                    'booked_date' => '2024-01-01',
+                    'processed_date' => '2024-01-01',
+                    'amount' => 9.99,
+                    'description' => 'Netflix EU',
+                    'transaction_id' => 'abc',
+                ],
+                true,
+            ],
+            'recurring payment different date' => [
+                [
+                    'booked_date' => '2024-01-01',
+                    'processed_date' => '2024-01-01',
+                    'amount' => 20.00,
+                    'description' => 'Gym',
+                    'transaction_id' => 'r1',
+                ],
+                [
+                    'booked_date' => '2024-01-10',
+                    'processed_date' => '2024-01-10',
+                    'amount' => 20.00,
+                    'description' => 'Gym',
+                    'transaction_id' => 'r2',
+                ],
+                false,
+            ],
+            'fuzzy description' => [
+                [
+                    'booked_date' => '2024-02-01',
+                    'processed_date' => '2024-02-01',
+                    'amount' => 15.00,
+                    'description' => 'Netflix EU',
+                    'transaction_id' => 'f1',
+                ],
+                [
+                    'booked_date' => '2024-02-01',
+                    'processed_date' => '2024-02-01',
+                    'amount' => 15.00,
+                    'description' => 'Netflx EU',
+                    'transaction_id' => 'f2',
+                ],
+                true,
+            ],
+            'mapped fields' => [
+                [
+                    'booked_date' => '2024-03-01',
+                    'processed_date' => '2024-03-01',
+                    'amount' => 30.00,
+                    'description' => 'Utility Bill',
+                    'transaction_id' => 'm1',
+                ],
+                [
+                    'date' => '2024-03-01',
+                    'processed_date' => '2024-03-01',
+                    'amount' => 30.00,
+                    'notes' => 'Utility Bill',
+                    'reference' => 'm1',
+                ],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider duplicateProvider
+     */
+    public function test_duplicate_detection(array $existing, array $new, bool $expected): void
+    {
+        $user = User::factory()->create();
+        $account = Account::create([
+            'user_id' => $user->id,
+            'name' => 'Test',
+            'bank_name' => 'Bank',
+            'iban' => 'DE89370400440532013000',
+            'type' => 'checking',
+            'currency' => 'EUR',
+            'balance' => 0,
+        ]);
+
+        $existing['account_id'] = $account->id;
+        $existingTransaction = Transaction::factory()->create($existing);
+
+        TransactionFingerprint::create([
+            'user_id' => $user->id,
+            'transaction_id' => $existingTransaction->id,
+            'fingerprint' => $this->service->buildFingerprint(
+                $this->service->normalizeRecord($existing)
+            ),
+        ]);
+
+        $new['account_id'] = $account->id;
+        $result = $this->service->isDuplicate($new, $user->id);
+
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- create `transaction_fingerprints` table for quick lookup
- add `TransactionFingerprint` model
- implement `TextSimilarity` helper
- refactor `DuplicateTransactionService` to use normalized fingerprints and fuzzy matching
- add unit tests for duplicate detection scenarios

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5ab3b088328ab31f6650258f636