### PR TITLE
Add Jest tests for components

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,9 +4,10 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx|js|jsx)$': 'ts-jest',
   },
   moduleNameMapper: {
+    '^@/Components/(.*)$': '<rootDir>/resources/js/components/$1',
     '^@/(.*)$': '<rootDir>/resources/js/$1',
     '\\.(css|scss)$': 'identity-obj-proxy',
   },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom';
+
+// Stub lucide-react icons for tests
+import React from 'react';
+
+jest.mock('lucide-react', () => {
+  return new Proxy(
+    {},
+    {
+      get: (_target, prop: string) => (props: React.SVGProps<SVGSVGElement>) =>
+        React.createElement('svg', { ...props, 'data-icon': prop }),
+    },
+  );
+});

--- a/resources/js/components/Import/ConfirmStep.test.tsx
+++ b/resources/js/components/Import/ConfirmStep.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfirmStep from './ConfirmStep';
+
+const post = jest.fn((_route: string, { onSuccess }: { onSuccess: () => void }) => onSuccess());
+
+jest.mock('@inertiajs/react', () => ({
+    useForm: () => ({
+        data: {},
+        setData: jest.fn(),
+        post,
+        processing: false,
+        errors: {},
+    }),
+}));
+
+describe('ConfirmStep', () => {
+    const importData = { id: 1, original_filename: 'file.csv', total_rows: 10 };
+
+    it('renders import details and handles submit', async () => {
+        const user = userEvent.setup();
+        const onBack = jest.fn();
+        const onComplete = jest.fn();
+
+        // stub ziggy route helper
+        (global as unknown as { route: () => string }).route = () => 'imports.process';
+
+        render(<ConfirmStep importData={importData} onBack={onBack} onComplete={onComplete} />);
+
+        expect(screen.getByText('file.csv')).toBeInTheDocument();
+        expect(screen.getByText('10 records')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        expect(post).toHaveBeenCalled();
+        expect(onComplete).toHaveBeenCalled();
+    });
+});

--- a/resources/js/components/accounts/AccountDetailMonthlyComparisonChart.test.tsx
+++ b/resources/js/components/accounts/AccountDetailMonthlyComparisonChart.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { Line } from 'react-chartjs-2';
+import AccountDetailMonthlyComparisonChart from './AccountDetailMonthlyComparisonChart';
+
+jest.mock('react-chartjs-2', () => ({
+    Line: jest.fn(() => <div data-testid="chart" />),
+}));
+
+describe('AccountDetailMonthlyComparisonChart', () => {
+    it('renders chart', () => {
+        render(
+            <AccountDetailMonthlyComparisonChart
+                currentMonthData={[{ date: '2024-06-01', balance: 10 }]}
+                previousMonthData={[{ date: '2024-05-01', balance: 5 }]}
+            />,
+        );
+        expect(screen.getByTestId('chart')).toBeInTheDocument();
+        expect(Line).toHaveBeenCalled();
+    });
+});

--- a/resources/js/components/accounts/CreateAccountModal.test.tsx
+++ b/resources/js/components/accounts/CreateAccountModal.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import CreateAccountModal from './CreateAccountModal';
+
+const submitMock = jest.fn();
+
+jest.mock('@/components/ui/form-modal', () => ({
+    FormModal: ({
+        children,
+        onSubmit,
+        defaultValues = {},
+    }: {
+        children: () => React.ReactNode;
+        onSubmit: (values: unknown) => void;
+        defaultValues?: Record<string, unknown>;
+    }) => {
+        const methods = useForm({ defaultValues });
+        return (
+            <FormProvider {...methods}>
+                <form data-testid="modal" onSubmit={methods.handleSubmit(onSubmit)}>
+                    {children()}
+                    <button type="submit">submit</button>
+                </form>
+            </FormProvider>
+        );
+    },
+}));
+
+describe('CreateAccountModal', () => {
+    it('renders when open and submits', async () => {
+        const user = userEvent.setup();
+        render(<CreateAccountModal isOpen onClose={jest.fn()} onSubmit={submitMock} />);
+
+        expect(screen.getByTestId('modal')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: /submit/i }));
+        expect(submitMock).toHaveBeenCalled();
+    });
+});

--- a/resources/js/components/settings/GoCardlessImportWizard.test.tsx
+++ b/resources/js/components/settings/GoCardlessImportWizard.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import GoCardlessImportWizard from './GoCardlessImportWizard';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+mockedAxios.get.mockResolvedValue({ data: [] });
+
+describe('GoCardlessImportWizard', () => {
+    it('advances to bank selection after choosing country', async () => {
+        const user = userEvent.setup();
+        render(<GoCardlessImportWizard isOpen onClose={jest.fn()} onSuccess={jest.fn()} />);
+
+        await user.click(screen.getByRole('button', { name: 'United Kingdom' }));
+        await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+        expect(screen.getByText(/select bank/i)).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/settings/requisition.test.tsx
+++ b/resources/js/components/settings/requisition.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Requisition from './requisition';
+
+const requisition = {
+    id: '1',
+    created: '2024-06-01',
+    redirect: '',
+    status: 'LN',
+    institution_id: 'Bank',
+    agreement: '2',
+    reference: '',
+    accounts: [],
+    user_language: 'en',
+    link: '/',
+    ssn: null,
+    account_selection: false,
+    redirect_immediate: false,
+};
+
+describe('Requisition', () => {
+    it('opens delete dialog', async () => {
+        const user = userEvent.setup();
+        render(<Requisition requisition={requisition} setRequisitions={jest.fn()} />);
+        await user.click(screen.getByRole('button', { name: /delete/i }));
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/transactions/BulkActionMenu.test.tsx
+++ b/resources/js/components/transactions/BulkActionMenu.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import BulkActionMenu from './BulkActionMenu';
+
+describe('BulkActionMenu', () => {
+    it('renders when transactions are selected', () => {
+        render(<BulkActionMenu selectedTransactions={['1']} categories={[]} merchants={[]} onUpdate={jest.fn()} />);
+        expect(screen.getByText(/assign category/i)).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/transactions/CreateTransactionModal.test.tsx
+++ b/resources/js/components/transactions/CreateTransactionModal.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import CreateTransactionModal from './CreateTransactionModal';
+
+const submitMock = jest.fn();
+
+jest.mock('@/components/ui/form-modal', () => ({
+    FormModal: ({
+        children,
+        onSubmit,
+        defaultValues = {},
+    }: {
+        children: () => React.ReactNode;
+        onSubmit: (values: unknown) => void;
+        defaultValues?: Record<string, unknown>;
+    }) => {
+        const methods = useForm({ defaultValues });
+        return (
+            <FormProvider {...methods}>
+                <form data-testid="modal" onSubmit={methods.handleSubmit(onSubmit)}>
+                    {children()}
+                    <button type="submit">submit</button>
+                </form>
+            </FormProvider>
+        );
+    },
+}));
+
+describe('CreateTransactionModal', () => {
+    it('renders and submits', async () => {
+        const user = userEvent.setup();
+        render(<CreateTransactionModal isOpen onClose={jest.fn()} onSubmit={submitMock} />);
+        expect(screen.getByTestId('modal')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: /submit/i }));
+        expect(submitMock).toHaveBeenCalled();
+    });
+});

--- a/resources/js/components/transactions/Transaction.test.tsx
+++ b/resources/js/components/transactions/Transaction.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Transaction from './Transaction';
+
+jest.mock('./TransactionDetails', () => () => <div data-testid="details" />);
+
+const baseTransaction = {
+    id: 1,
+    transaction_id: 'trx',
+    amount: -10,
+    currency: 'EUR',
+    booked_date: '2024-06-01',
+    processed_date: '2024-06-01',
+    description: 'd',
+    type: 'card',
+    balance_after_transaction: 0,
+    account_id: 1,
+    partner: 'Partner',
+};
+
+describe('Transaction', () => {
+    it('toggles details on click', async () => {
+        const user = userEvent.setup();
+        render(<Transaction {...baseTransaction} />);
+        const card = screen.getByText('Partner').closest('div');
+        expect(screen.queryByTestId('details')).not.toBeInTheDocument();
+        if (card) {
+            await user.click(card);
+        }
+        expect(screen.getByTestId('details')).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/transactions/TransactionDetails.test.tsx
+++ b/resources/js/components/transactions/TransactionDetails.test.tsx
@@ -1,0 +1,24 @@
+import { Transaction as TransactionType } from '@/types';
+import { render, screen } from '@testing-library/react';
+import TransactionDetails from './TransactionDetails';
+
+const transaction: TransactionType = {
+    id: 1,
+    transaction_id: 't',
+    amount: -10,
+    currency: 'EUR',
+    booked_date: '2024-06-01',
+    processed_date: '2024-06-01',
+    description: 'desc',
+    type: 'card',
+    balance_after_transaction: 0,
+    account_id: 1,
+};
+
+describe('TransactionDetails', () => {
+    it('renders transaction info', () => {
+        render(<TransactionDetails transaction={transaction} />);
+        expect(screen.getByText('desc')).toBeInTheDocument();
+        expect(screen.getByText('card')).toBeInTheDocument();
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -118,5 +118,7 @@
         "resources/js/**/*.ts",
         "resources/js/**/*.d.ts",
         "resources/js/**/*.tsx",
+        "resources/js/**/*.js",
+        "resources/js/**/*.jsx"
     ]
 }


### PR DESCRIPTION
## Summary
- add comprehensive tests for multiple React components
- update Jest config for JSX support and alias mapping
- stub lucide-react icons globally for tests
- include JavaScript files in tsconfig

## Testing
- `npm run test`
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68554f8d53e883289181b557a21b9972