### PR TITLE
Fix NaN in Analytics Summary Resulting Balance for daily cashflow data

### DIFF
--- a/resources/js/pages/Analytics/Index.tsx
+++ b/resources/js/pages/Analytics/Index.tsx
@@ -546,7 +546,7 @@ export default function Index({
     // Calculate totals for summary
     const totalIncome = cashflow.reduce((sum, item) => sum + item.total_income, 0);
     const totalExpenses = cashflow.reduce((sum, item) => sum + item.total_expenses, 0);
-    const netBalance = cashflow.reduce((sum, item) => sum + item.month_balance, 0);
+    const netBalance = totalIncome - totalExpenses;
     const totalTransactions = cashflow.reduce((sum, item) => sum + item.transaction_count, 0);
 
     // Format the cashflow chart title based on period


### PR DESCRIPTION
## Summary
- Fixes NaN display issue in Analytics Summary's "Resulting Balance" field when viewing short date ranges (< 32 days)
- The issue occurred because the frontend was trying to sum `item.month_balance` which is undefined for daily cashflow data
- Changed the calculation to use `totalIncome - totalExpenses` which works correctly for both daily and monthly data

## Changes Made
- Modified `netBalance` calculation in `resources/js/pages/Analytics/Index.tsx:549`
- Changed from `cashflow.reduce((sum, item) => sum + item.month_balance, 0)` to `totalIncome - totalExpenses`

## Test Plan
- [x] Verified the fix resolves the NaN issue by using fields that are always present in the cashflow data
- [x] Confirmed the calculation works for both daily and monthly aggregated data
- [ ] Manual testing on various date ranges (Last Month, Current Month, Specific Month, Custom ranges)

Fixes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Net Balance in Analytics to be calculated from overall income minus expenses, improving consistency with displayed totals.
  * You may notice slight differences in the Net Balance compared to previous versions if per-item balances previously diverged from totals.
  * Charts and the “Resulting Balance” series remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->