### PR TITLE
Fix: prevent brand text overflow in collapsed sidebar

### DIFF
--- a/resources/js/components/app/app-sidebar.test.tsx
+++ b/resources/js/components/app/app-sidebar.test.tsx
@@ -1,0 +1,43 @@
+import { SidebarProvider } from '@/components/ui/sidebar';
+import { render, screen } from '@testing-library/react';
+import { AppSidebar } from './app-sidebar';
+
+// Mock ESM icons to avoid Jest ESM transform issues
+jest.mock('lucide-react', () => new Proxy({}, { get: () => () => null }));
+jest.mock('@/components/app/sidebar/nav-main', () => ({ NavMain: () => null }));
+jest.mock('@/components/app/sidebar/nav-footer', () => ({ NavFooter: () => null }));
+jest.mock('@/components/app/sidebar/nav-user', () => ({ NavUser: () => null }));
+
+describe('AppSidebar', () => {
+    it('renders brand name with truncation and collapse-hiding classes', () => {
+        // Mock matchMedia used by useIsMobile
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                addListener: jest.fn(),
+                removeListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+
+        const { container } = render(
+            <SidebarProvider>
+                <AppSidebar />
+            </SidebarProvider>,
+        );
+
+        const brand = screen.getByText('Spendly');
+        expect(brand).toBeInTheDocument();
+        const className = brand.getAttribute('class') ?? '';
+        expect(className).toContain('truncate');
+        expect(className).toContain('group-data-[collapsible=icon]:hidden');
+
+        // Ensure the icon is present so hiding text in collapsed mode still shows a brand mark
+        expect(container.querySelector('#logo_svg')).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/app/app-sidebar.tsx
+++ b/resources/js/components/app/app-sidebar.tsx
@@ -72,9 +72,9 @@ export function AppSidebar() {
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>
-                <div className="flex flex-row items-center justify-start rounded-md">
-                    <AppLogoIcon className="size-20 fill-current text-[var(--foreground)] dark:text-white" />
-                    <span className="text-3xl font-bold">Spendly</span>
+                <div className="flex min-w-0 flex-row items-center justify-start gap-2 rounded-md">
+                    <AppLogoIcon className="size-20 shrink-0 fill-current text-[var(--foreground)] dark:text-white" />
+                    <span className="truncate text-3xl font-bold group-data-[collapsible=icon]:hidden">Spendly</span>
                 </div>
             </SidebarHeader>
 


### PR DESCRIPTION
Summary
- Hide brand text in collapsed sidebar (icon-only) using Tailwind variant `group-data-[collapsible=icon]:hidden`
- Add truncation (`truncate`) plus container `min-w-0` so text never overflows when expanded but space-constrained
- Ensure logo icon is non-shrinking (`shrink-0`) so visual mark remains in collapsed mode
- Add Jest test to assert presence of truncation + collapsed-hidden classes on the brand element

Why
Fixes #46. When the sidebar is collapsed, the app name "Spendly" overflowed into the content area. This change keeps the layout clean in collapsed mode without impacting expanded mode.

Scope
- Frontend-only CSS/TSX change in `resources/js/components/app/app-sidebar.tsx`
- New test `resources/js/components/app/app-sidebar.test.tsx`
- No breaking changes; behavior is unchanged in expanded mode.

Verification
- `npm ci && npm run build` succeeds
- `npm test` passes existing suites and new sidebar test
- Manual reasoning: Tailwind `group-data-[collapsible=icon]:hidden` targets sidebar collapsed icon mode; the logo icon remains visible.

Notes on linting
ESLint reports unrelated errors elsewhere in the repo; this PR keeps changes minimal and focused on the issue.

AI disclosure
This change was proposed and implemented with assistance from an AI coding agent (OpenAI Codex CLI). I reviewed and validated the patch, build, and tests.
