### PR TITLE
fix: prevent collapsed sidebar brand overflow

### DIFF
--- a/resources/js/components/app/app-sidebar.tsx
+++ b/resources/js/components/app/app-sidebar.tsx
@@ -77,9 +77,9 @@ export function AppSidebar() {
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>
-                <div className="flex flex-row items-center justify-start rounded-md">
-                    <AppLogoIcon className="size-20 fill-current text-[var(--foreground)] dark:text-white" />
-                    <span className="text-3xl font-bold">Spendly</span>
+                <div className="flex min-w-0 flex-row items-center justify-start overflow-hidden rounded-md group-data-[collapsible=icon]:justify-center">
+                    <AppLogoIcon className="size-20 shrink-0 fill-current text-[var(--foreground)] group-data-[collapsible=icon]:size-8 dark:text-white" />
+                    <span className="truncate text-3xl font-bold group-data-[collapsible=icon]:hidden">Spendly</span>
                 </div>
             </SidebarHeader>
 


### PR DESCRIPTION
Fixes #46

## Summary

- Prevent the collapsed sidebar header from overflowing its icon-width container.
- Keep the logo visible at icon size while hiding the brand text in collapsed mode.
- Preserve the expanded sidebar brand layout with truncation protection.

## Testing

- `git diff --check origin/develop..HEAD`
- `npx eslint resources/js/components/app/app-sidebar.tsx`
- `npx prettier --check resources/js/components/app/app-sidebar.tsx`
