### PR TITLE
Fix possible fix(deps): 7 vulnerable dependencies in requirements.txt

### DIFF
--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -6,7 +6,7 @@ certifi==2025.1.31
 charset-normalizer==3.4.1
 exceptiongroup==1.2.2
 fastapi==0.115.8
-h11==0.14.0
+h11==0.16.0
 idna==3.10
 joblib==1.4.2
 Levenshtein==0.27.1
@@ -22,9 +22,9 @@ scipy==1.15.2
 six==1.17.0
 sniffio==1.3.1
 SQLAlchemy==2.0.38
-starlette==0.45.3
+starlette==1.3.1
 threadpoolctl==3.6.0
 typing_extensions==4.12.2
 Unidecode==1.3.8
-urllib3==2.3.0
+urllib3==2.6.3
 uvicorn==0.34.0


### PR DESCRIPTION
Proposing a fix for something flagged in `ml/requirements.txt`. It is around line 9.

CRITICAL vulnerability: CVE-2025-43859 affects h11 0.14.0, a Python HTTP/1.1 protocol library commonly used by ASGI servers (uvicorn, hypercorn) and HTTP clients (httpcore). The library is overly lenient when parsing line terminators in chunked transfer-encoding message bodies, accepting non-standard terminators. This inconsistency can enable HTTP Request Smuggling when h11 sits behind a (reverse) proxy that interprets the same request differently (CL.TE / TE.CL desync). Impact includes bypassing front-end security controls (WAF, auth gates, rate limiters), cache poisoning, routing unintended requests to internal endpoints, and potential credential/session hijacking. Severity is CRITICAL because request smuggling on a production ML API ingress can lead to full bypass of access controls. Mitigation note: exploitation requires BOTH a buggy h11 and a buggy proxy, so patching either component mitigates the issue — but upgrading h11 to >= 0.16.0 is the direct fix and should be applied immediately. After updating requirements.txt, regenerate any lock files and redeploy.

Upgrade vulnerable dependencies in ml/requirements.txt to versions that resolve the reported CVEs.

For reference: rule `CVE-2025-43859`. Rated critical.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supporting components to newer versions.
  * Includes improvements to networking and web request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->